### PR TITLE
Fix/nanos update compiler warnings

### DIFF
--- a/src/common/nvswitch/kernel/inc/inforom/inforom_nvswitch.h
+++ b/src/common/nvswitch/kernel/inc/inforom/inforom_nvswitch.h
@@ -90,23 +90,23 @@ struct inforom
 // Generic InfoROM APIs
 NvlStatus nvswitch_initialize_inforom(nvswitch_device *device);
 NvlStatus nvswitch_inforom_read_object(nvswitch_device* device,
-                const char *objectName, const char *pObjectFormat,
+                const char objectName[3], const char *pObjectFormat,
                 NvU8 *pPackedObject, void *pObject);
 NvlStatus nvswitch_inforom_write_object(nvswitch_device* device,
-                const char *objectName, const char *pObjectFormat,
+                const char objectName[3], const char *pObjectFormat,
                 void *pObject, NvU8 *pOldPackedObject);
 void nvswitch_destroy_inforom(nvswitch_device *device);
 NvlStatus nvswitch_inforom_add_object(struct inforom *pInforom,
                                     INFOROM_OBJECT_HEADER_V1_00 *pHeader);
 NvlStatus nvswitch_inforom_get_object_version_info(nvswitch_device *device,
-                const char *objectName, NvU8 *pVersion, NvU8 *pSubVersion);
+                const char objectName[3], NvU8 *pVersion, NvU8 *pSubVersion);
 void *nvswitch_add_halinfo_node(NVListPtr head, int type, int size);
 void *nvswitch_get_halinfo_node(NVListPtr head, int type);
 void nvswitch_inforom_post_init(nvswitch_device *device);
 NvlStatus nvswitch_initialize_inforom_objects(nvswitch_device *device);
 void nvswitch_destroy_inforom_objects(nvswitch_device *device);
 NvlStatus nvswitch_inforom_load_object(nvswitch_device* device,
-                struct inforom *pInforom, const char *objectName,
+                struct inforom *pInforom, const char objectName[3],
                 const char *pObjectFormat, NvU8 *pPackedObject, void *pObject);
 void nvswitch_inforom_read_static_data(nvswitch_device *device,
                 struct inforom  *pInforom, RM_SOE_SMBPBI_INFOROM_DATA *pData);

--- a/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
+++ b/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
@@ -1633,7 +1633,7 @@ NV_STATUS nvGpuOpsDeviceCreate(struct gpuSession *session,
     NV2080_CTRL_CMD_NVLINK_GET_NVLINK_STATUS_PARAMS *nvlinkStatus;
     NvU32 nvlinkVersion;
     NvU32 sysmemLink;
-    NvU32 linkBandwidthMBps;
+    NvU32 linkBandwidthMBps = 0;
     NvU32 sysmemConnType;
     NvBool atomicSupported;
     RM_API *pRmApi = rmapiGetInterface(RMAPI_EXTERNAL_KERNEL);

--- a/src/nvidia/src/libraries/mmu/mmu_walk.c
+++ b/src/nvidia/src/libraries/mmu/mmu_walk.c
@@ -299,7 +299,7 @@ NV_STATUS mmuWalkProcessPdes
             NvU32 entryIndexHi = mmuFmtVirtAddrToEntryIndex(pLevel->pFmt, vaHi);
             NvU32 entryIndex;
             NvU32 index;
-            NvU32 entryIndexFillStart;
+            NvU32 entryIndexFillStart = 0;
             NvU32 entryIndexFillEnd;
             NvU32 pendingFillCount = 0;
 
@@ -685,7 +685,7 @@ cleanupIter:
         NvU32        entryIndexHi = mmuFmtVirtAddrToEntryIndex(pLevel->pFmt, vaHi);
         NvU32        entryIndex;
         NvU32        index;
-        NvU32        entryIndexFillStart;
+        NvU32        entryIndexFillStart = 0;
         NvU32        entryIndexFillEnd;
         NvU32        pendingFillCount = 0;
 


### PR DESCRIPTION
This PR fixes couple warnings (interpreted as errors) that I got when compiling the latest updated version of `gpu-nvidia`.

I use Fedora 37. Here's `gcc -v`:
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-12.3.1-20230508/obj-x86_64-redhat-linux/isl-install --enable-offload-targets=nvptx-none --without-cuda-driver --enable-offload-defaulted --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.3.1 20230508 (Red Hat 12.3.1-1) (GCC) 
```