### PR TITLE
Fix string arguments to create_special_file() and snprintf()

### DIFF
--- a/kernel-open/common/inc/nv-nanos.h
+++ b/kernel-open/common/inc/nv-nanos.h
@@ -400,15 +400,16 @@ typedef struct nvidia_event
 #define likely(x)   (x)
 #define unlikely(x) (x)
 
+#define sstring_from_cstr(s)    isstring((char *)(s), os_string_length(s))
+
 #define memcpy(d, s, n)         ({ runtime_memcpy(d, s, n); d; })
 #define memset(p, v, l)         ({ runtime_memset((void *)(p), v, l); (void *)(p); })
 #define memcmp                  runtime_memcmp
 #define strcmp                  os_string_compare
 #define strlen                  os_string_length
 #define strstr(_h, _n)          \
-    runtime_strstr(isstring((char *)(_h), os_string_length(_h)),    \
-                   isstring((char *)(_n), os_string_length(_n)))
-#define strchr(_s, _c)          runtime_strchr(isstring((char *)(_s), os_string_length(_s)), _c)
+    runtime_strstr(sstring_from_cstr(_h), sstring_from_cstr(_n))
+#define strchr(_s, _c)          runtime_strchr(sstring_from_cstr(_s), _c)
 #define strncpy(dest, src, len) ({  \
     runtime_memcpy(dest, src, MIN(os_string_length(src) + 1, len)); dest; \
 })

--- a/kernel-open/nvidia-uvm/uvm_channel.c
+++ b/kernel-open/nvidia-uvm/uvm_channel.c
@@ -1936,9 +1936,9 @@ static NV_STATUS internal_channel_create(uvm_channel_t *channel)
              channel_info->hwChannelId,
              channel_info->hwRunlistId,
              channel_info->hwChannelId,
-             uvm_channel_is_sec2(channel) ? "SEC2" :
-             uvm_channel_is_wlc(channel) ? "WLC" :
-             uvm_channel_is_lcic(channel) ? "LCIC" : "CE",
+             uvm_channel_is_sec2(channel) ? ss("SEC2") :
+             uvm_channel_is_wlc(channel) ? ss("WLC") :
+             uvm_channel_is_lcic(channel) ? ss("LCIC") : ss("CE"),
              channel->pool->engine_index);
 
     return NV_OK;

--- a/kernel-open/nvidia-uvm/uvm_gpu.c
+++ b/kernel-open/nvidia-uvm/uvm_gpu.c
@@ -120,8 +120,8 @@ static void fill_gpu_info(uvm_parent_gpu_t *parent_gpu, const UvmGpuInfo *gpu_in
              sizeof(parent_gpu->name),
              "ID %u: %s: %s",
              uvm_id_value(parent_gpu->id),
-             parent_gpu->rm_info.name,
-             uuid_buffer);
+             sstring_from_cstr(parent_gpu->rm_info.name),
+             sstring_from_cstr(uuid_buffer));
 }
 
 static NV_STATUS get_gpu_caps(uvm_gpu_t *gpu)

--- a/kernel-open/nvidia/nv-frontend.c
+++ b/kernel-open/nvidia/nv-frontend.c
@@ -206,20 +206,22 @@ int nvidia_frontend_add_device(nvidia_module_t *module, nv_nanos_state_t * devic
 
             if (open != INVALID_ADDRESS) {
                 char file_path[] = "/dev/nvidiaXXX";
+                bytes file_path_len;
 
                 if (minor < 10) {
                     file_path[11] = '0' + minor;
-                    file_path[12] = '\0';
+                    file_path_len = 12;
                 } else if (minor < 100) {
                     file_path[11] = '0' + minor / 10;
                     file_path[12] = '0' + minor % 10;
-                    file_path[13] = '\0';
+                    file_path_len = 13;
                 } else {
                     file_path[11] = '0' + minor / 100;
                     file_path[12] = '0' + (minor / 10) % 10;
                     file_path[13] = '0' + minor % 10;
+                    file_path_len = 14;
                 }
-                if (!create_special_file(isstring(file_path, sizeof(file_path) - 1), open, 0,
+                if (!create_special_file(isstring(file_path, file_path_len), open, 0,
                     makedev(NV_MAJOR_DEVICE_NUMBER, minor))) {
                     deallocate_closure(open);
                     rc = -1;

--- a/kernel-open/nvidia/nv.c
+++ b/kernel-open/nvidia/nv.c
@@ -3072,7 +3072,7 @@ void NV_API_CALL nv_fetch_firmware(
     pagecache_node pn;
     range r;
 
-    fsf = fsfile_open(isstring((char *)file_path, os_string_length(file_path)));
+    fsf = fsfile_open(sstring_from_cstr(file_path));
     if (!fsf)
         return;
     len = fsfile_get_length(fsf);

--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -375,8 +375,7 @@ NvU32 NV_API_CALL os_strtoul(const char *str, char **endp, NvU32 base)
 
 NvS32 NV_API_CALL os_string_compare(const char *str1, const char *str2)
 {
-    return runtime_strcmp(isstring((char *)str1, os_string_length(str1)),
-                          isstring((char *)str2, os_string_length(str2)));
+    return runtime_strcmp(sstring_from_cstr(str1), sstring_from_cstr(str2));
 }
 
 void *os_mem_copy_custom(
@@ -1533,7 +1532,7 @@ NvU32 NV_API_CALL os_get_grid_csp_support(void)
 
 void NV_API_CALL os_bug_check(NvU32 bugCode, const char *bugCodeStr)
 {
-    halt_with_code(bugCode, isstring((char *)bugCodeStr, os_string_length(bugCodeStr)));
+    halt_with_code(bugCode, sstring_from_cstr(bugCodeStr));
 }
 
 NV_STATUS NV_API_CALL os_get_euid(NvU32 *pSecToken)


### PR DESCRIPTION
This fixes a "_NVRM nvAssertFailedNoLog: Assertion failed: rmapiLockIsOwner() && rmGpuLockIsOwner() @ conf_compute_api.c:76_" error that occurs during initialization of a CUDA application (bug introduced in commit b4b0d769).