### PR TITLE
uvm_nanos.h: move inclusion of net_system_structs.h

### DIFF
--- a/kernel-open/nvidia-uvm/uvm_nanos.h
+++ b/kernel-open/nvidia-uvm/uvm_nanos.h
@@ -3,9 +3,9 @@
 
 #ifndef _KERNEL_H_
 #define _KERNEL_H_
-#include <net_system_structs.h>
 #include <unix_internal.h>
 #include <filesystem.h>
+#include <net_system_structs.h>
 #endif
 
 #include "nvtypes.h"


### PR DESCRIPTION
uvm_nanos.h includes the net_system_structs.h header file from the kernel source because the UVM driver uses the standard Unix error number definitions, some of which are in that header file. Since the addition of the tcp_info struct definition in the header file, building the UVM driver fails because of missing definitions of the u8, u32 and u64 data types. Moving the inclusion of the header in uvm_nanos.h to after the inclusion of unix_internal.h fixes the build failure.