### PR TITLE
Page fault: add implementation of fault handlers

### DIFF
--- a/kernel-open/common/inc/nv-nanos.h
+++ b/kernel-open/common/inc/nv-nanos.h
@@ -677,6 +677,12 @@ static inline sysreturn nv_io_remap_page_range(vmap vm, NvU64 phys_addr, NvU64 s
     return virt;
 }
 
+static inline status nv_insert_pfn(vmap vma, NvU64 virt_addr, NvU64 pfn, NvU32 extra_prot)
+{
+    map(virt_addr, pfn, PAGESIZE, pageflags_from_vmflags(vma->flags));
+    return STATUS_OK;
+}
+
 #define NV_GET_CURRENT_PROCESS()        ({ thread t = current; int pid = t ? t->p->pid : 0; pid; })
 #define NV_COPY_TO_USER(to, from, n)    (copy_to_user(to, from, n) == false)
 #define NV_COPY_FROM_USER(to, from, n)  (copy_from_user(from, to, n) == false)

--- a/kernel-open/nvidia-uvm/uvm_gpu.h
+++ b/kernel-open/nvidia-uvm/uvm_gpu.h
@@ -139,7 +139,7 @@ struct uvm_service_block_context_struct
         // section.
         unsigned long notifier_seq;
 
-        struct vm_fault *vmf;
+        context ctx;
     } cpu_fault;
 
     //

--- a/kernel-open/nvidia-uvm/uvm_nanos.h
+++ b/kernel-open/nvidia-uvm/uvm_nanos.h
@@ -291,7 +291,7 @@ static inline boolean bitmap_full(const unsigned long *map, unsigned int nbits)
 
 static inline void bitmap_cpy(unsigned long *dst, const unsigned long *src, unsigned int nbits)
 {
-    runtime_memcpy(dst, src, (nbits + 63) / 64);
+    runtime_memcpy(dst, src, sizeof(*src) * ((nbits + 63) / 64));
 }
 #define bitmap_copy  bitmap_cpy
 

--- a/kernel-open/nvidia-uvm/uvm_va_range.c
+++ b/kernel-open/nvidia-uvm/uvm_va_range.c
@@ -185,7 +185,7 @@ NV_STATUS uvm_va_range_create_mmap(uvm_va_space_t *va_space,
                                    uvm_va_range_t **out_va_range)
 {
     NV_STATUS status;
-    vmap vma = vma_wrapper->vma;
+    vmap vma = &vma_wrapper->vma;
     uvm_va_range_t *va_range = NULL;
 
     // Check for no overlap with HMM blocks.
@@ -1688,7 +1688,7 @@ uvm_vma_wrapper_t *uvm_vma_wrapper_alloc(vmap vma)
     if (!vma_wrapper)
         return NULL;
 
-    vma_wrapper->vma = vma;
+    runtime_memcpy(&vma_wrapper->vma, vma, sizeof(*vma));
     uvm_init_rwsem(&vma_wrapper->lock, UVM_LOCK_ORDER_LEAF);
 
     return vma_wrapper;

--- a/kernel-open/nvidia-uvm/uvm_va_range.h
+++ b/kernel-open/nvidia-uvm/uvm_va_range.h
@@ -118,7 +118,7 @@ typedef struct
 {
     // Needed for creating CPU mappings on the va_range. Do not access this
     // directly, instead use uvm_va_range_vma and friends.
-    vmap vma;
+    struct vmap vma;
 
     uvm_rw_semaphore_t lock;
 } uvm_vma_wrapper_t;
@@ -651,7 +651,7 @@ static vmap uvm_va_range_vma(uvm_va_range_t *va_range)
     // vm_file, vm_private_data, vm_start, and vm_end are all safe to access
     // here because they can't change without the kernel calling vm_ops->open
     // or vm_ops->close, which both take va_space->lock.
-    vma = va_range->managed.vma_wrapper->vma;
+    vma = &va_range->managed.vma_wrapper->vma;
     UVM_ASSERT(vma);
     UVM_ASSERT_MSG(va_range->node.start >= vma->node.r.start,
                    "Range mismatch: va_range: [0x%lx, 0x%lx] vma: [0x%lx, 0x%lx]\n",

--- a/kernel-open/nvidia-uvm/uvm_va_space.h
+++ b/kernel-open/nvidia-uvm/uvm_va_space.h
@@ -847,9 +847,7 @@ NV_STATUS uvm_test_destroy_gpu_va_space_delay(UVM_TEST_DESTROY_GPU_VA_SPACE_DELA
 // VM_FAULT_OOM: if system memory wasn't available.
 // VM_FAULT_SIGBUS: if a CPU mapping to fault_addr cannot be accessed,
 //     for example because it's within a range group which is non-migratable.
-vm_fault_t uvm_va_space_cpu_fault_managed(uvm_va_space_t *va_space,
-                                          struct vm_area_struct *vma,
-                                          struct vm_fault *vmf);
+status uvm_va_space_cpu_fault_managed(uvm_va_space_t *va_space, context ctx, u64 vaddr);
 
 // Handle a CPU fault in the given VA space for a HMM allocation,
 // performing any operations necessary to establish a coherent CPU mapping
@@ -863,8 +861,6 @@ vm_fault_t uvm_va_space_cpu_fault_managed(uvm_va_space_t *va_space,
 //     (possibly or'ed with VM_FAULT_MAJOR if a migration was needed).
 // VM_FAULT_OOM: if system memory wasn't available.
 // VM_FAULT_SIGBUS: if a CPU mapping to fault_addr cannot be accessed.
-vm_fault_t uvm_va_space_cpu_fault_hmm(uvm_va_space_t *va_space,
-                                      struct vm_area_struct *vma,
-                                      struct vm_fault *vmf);
+status uvm_va_space_cpu_fault_hmm(uvm_va_space_t *va_space, context ctx, u64 vaddr);
 
 #endif // __UVM_VA_SPACE_H__


### PR DESCRIPTION
This changeset adds a page fault handler implementation for the /dev/nvidiaXXX and /dev/nvidia-uvm special files. Depends on https://github.com/nanovms/nanos/pull/2064.
The first 2 commits contain fixes for the bitmap_copy() and nv_get_firmware() functions.